### PR TITLE
Add Social and Newsletter block pages

### DIFF
--- a/src/blocks/media-communication/newsletter/index.html
+++ b/src/blocks/media-communication/newsletter/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Newsletter Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <a href="/src/blocks/media-communication/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Media & Communication</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Newsletter</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Newsletter Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Signup forms for collecting emails and growing your audience.
+          </p>
+        </div>
+
+        <!-- Section: Simple Signup -->
+        <section id="simple-signup" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Simple Signup</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Basic email capture form.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-simple-signup-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="simple-signup-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="simple-signup-html">HTML</button>
+            </nav>
+          </div>
+          <div id="simple-signup-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 max-w-md mx-auto flex space-x-2">
+              <input type="email" placeholder="Enter your email" class="flex-1 px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100" />
+              <button class="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors">Subscribe</button>
+            </div>
+          </div>
+          <div id="simple-signup-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;flex space-x-2 max-w-md mx-auto&quot;&gt;
+  &lt;input type=&quot;email&quot; placeholder=&quot;Enter your email&quot; class=&quot;flex-1 px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100&quot; /&gt;
+  &lt;button class=&quot;bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors&quot;&gt;Subscribe&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Image Signup -->
+        <section id="image-signup" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Image Signup</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Form with accompanying image.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-image-signup-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="image-signup-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="image-signup-html">HTML</button>
+            </nav>
+          </div>
+          <div id="image-signup-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 flex items-center space-x-6 max-w-xl mx-auto">
+              <div class="w-32 h-32 bg-neutral-300 dark:bg-neutral-700 rounded-lg"></div>
+              <div class="flex-1 flex space-x-2">
+                <input type="email" placeholder="Your email" class="flex-1 px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100" />
+                <button class="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors">Join</button>
+              </div>
+            </div>
+          </div>
+          <div id="image-signup-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;flex items-center space-x-6 max-w-xl mx-auto&quot;&gt;
+  &lt;div class=&quot;w-32 h-32 bg-neutral-300 dark:bg-neutral-700 rounded-lg&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;flex-1 flex space-x-2&quot;&gt;
+    &lt;input type=&quot;email&quot; placeholder=&quot;Your email&quot; class=&quot;flex-1 px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100&quot; /&gt;
+    &lt;button class=&quot;bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors&quot;&gt;Join&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Card Signup -->
+        <section id="card-signup" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Card Signup</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Centered card style form.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-card-signup-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="card-signup-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="card-signup-html">HTML</button>
+            </nav>
+          </div>
+          <div id="card-signup-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 max-w-md mx-auto text-center space-y-4">
+              <p class="text-lg font-medium text-neutral-900 dark:text-neutral-100">Join our newsletter</p>
+              <input type="email" placeholder="Email address" class="w-full px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100" />
+              <button class="w-full bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors">Sign Up</button>
+            </div>
+          </div>
+          <div id="card-signup-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;max-w-md mx-auto text-center space-y-4&quot;&gt;
+  &lt;p class=&quot;text-lg font-medium text-neutral-900 dark:text-neutral-100&quot;&gt;Join our newsletter&lt;/p&gt;
+  &lt;input type=&quot;email&quot; placeholder=&quot;Email address&quot; class=&quot;w-full px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100&quot; /&gt;
+  &lt;button class=&quot;w-full bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors&quot;&gt;Sign Up&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('newsletter');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-simple-signup-btn', content: 'simple-signup-html' },
+          { id: 'copy-image-signup-btn', content: 'image-signup-html' },
+          { id: 'copy-card-signup-btn', content: 'card-signup-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>

--- a/src/blocks/media-communication/social/index.html
+++ b/src/blocks/media-communication/social/index.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Social Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <a href="/src/blocks/media-communication/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Media & Communication</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Social</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Social Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Elements for displaying social links, profile cards, and share actions.
+          </p>
+        </div>
+
+        <!-- Section: Social Icons -->
+        <section id="social-icons" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Social Icons</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Row of social media icons.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-social-icons-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="social-icons-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="social-icons-html">HTML</button>
+            </nav>
+          </div>
+          <div id="social-icons-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8">
+              <div class="flex justify-center space-x-4">
+                <div class="w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700"></div>
+                <div class="w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700"></div>
+                <div class="w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700"></div>
+                <div class="w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700"></div>
+              </div>
+            </div>
+          </div>
+          <div id="social-icons-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;flex justify-center space-x-4&quot;&gt;
+  &lt;div class=&quot;w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;w-8 h-8 rounded-full bg-neutral-300 dark:bg-neutral-700&quot;&gt;&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Social Card -->
+        <section id="social-card" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Social Card</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Profile card with follow button.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-social-card-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="social-card-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="social-card-html">HTML</button>
+            </nav>
+          </div>
+          <div id="social-card-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 max-w-sm mx-auto text-center space-y-4">
+              <div class="w-20 h-20 rounded-full bg-neutral-300 dark:bg-neutral-700 mx-auto"></div>
+              <p class="font-medium text-neutral-900 dark:text-neutral-100">@ui11design</p>
+              <button class="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors">Follow</button>
+            </div>
+          </div>
+          <div id="social-card-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;max-w-sm mx-auto text-center space-y-4&quot;&gt;
+  &lt;div class=&quot;w-20 h-20 rounded-full bg-neutral-300 dark:bg-neutral-700 mx-auto&quot;&gt;&lt;/div&gt;
+  &lt;p class=&quot;font-medium text-neutral-900 dark:text-neutral-100&quot;&gt;@ui11design&lt;/p&gt;
+  &lt;button class=&quot;bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-lg transition-colors&quot;&gt;Follow&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Share Buttons -->
+        <section id="share-buttons" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Share Buttons</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Buttons to share content.</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <button data-theme-toggle class="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors duration-normal" aria-label="Toggle theme">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+                </button>
+                <button id="copy-share-buttons-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="mb-6">
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="share-buttons-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="share-buttons-html">HTML</button>
+            </nav>
+          </div>
+          <div id="share-buttons-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 flex justify-center space-x-4">
+              <button class="px-4 py-2 bg-blue-500 text-white rounded-lg">Twitter</button>
+              <button class="px-4 py-2 bg-primary-500 text-white rounded-lg">Facebook</button>
+              <button class="px-4 py-2 bg-neutral-600 text-white rounded-lg">LinkedIn</button>
+            </div>
+          </div>
+          <div id="share-buttons-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <div class="w-full">
+                <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words" style="word-break: break-all; max-width: 100%;">&lt;div class=&quot;flex justify-center space-x-4&quot;&gt;
+  &lt;button class=&quot;px-4 py-2 bg-blue-500 text-white rounded-lg&quot;&gt;Twitter&lt;/button&gt;
+  &lt;button class=&quot;px-4 py-2 bg-primary-500 text-white rounded-lg&quot;&gt;Facebook&lt;/button&gt;
+  &lt;button class=&quot;px-4 py-2 bg-neutral-600 text-white rounded-lg&quot;&gt;LinkedIn&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('social');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-social-icons-btn', content: 'social-icons-html' },
+          { id: 'copy-social-card-btn', content: 'social-card-html' },
+          { id: 'copy-share-buttons-btn', content: 'share-buttons-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add social block page with icons, profile card, and share buttons
- add newsletter block page with three signup variations

## Testing
- `npm run tw:build` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_684233fa49608333ac7740fe61081015