### PR TITLE
Add feedback & status block pages

### DIFF
--- a/src/blocks/feedback-status/banner/index.html
+++ b/src/blocks/feedback-status/banner/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Banner Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <a href="/src/blocks/feedback-status/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Feedback &amp; Status</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Banner</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Banner Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Notification banners for announcements and promotions.
+          </p>
+        </div>
+
+        <!-- Section: Announcement Banner -->
+        <section id="banner-announcement" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Announcement Banner</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Important information for users.</p>
+              </div>
+              <button id="copy-banner-announcement-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="banner-announcement-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="banner-announcement-html">HTML</button>
+            </nav>
+          </div>
+          <div id="banner-announcement-preview" class="tab-content">
+            <div class="bg-primary-500 text-white px-4 py-3 rounded-lg">
+              <p>We just launched a new feature! Check it out.</p>
+            </div>
+          </div>
+          <div id="banner-announcement-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;background-primary-500 text-white px-4 py-3 rounded-lg&quot;&gt;
+  &lt;p&gt;We just launched a new feature! Check it out.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Promotional Banner -->
+        <section id="banner-promotional" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Promotional Banner</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Marketing message and call to action.</p>
+              </div>
+              <button id="copy-banner-promotional-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="banner-promotional-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="banner-promotional-html">HTML</button>
+            </nav>
+          </div>
+          <div id="banner-promotional-preview" class="tab-content">
+            <div class="bg-neutral-900 text-white px-4 py-3 rounded-lg flex items-center justify-between">
+              <span>Get 20% off your next purchase!</span>
+              <a href="#" class="underline">Shop Now</a>
+            </div>
+          </div>
+          <div id="banner-promotional-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;background-neutral-900 text-white px-4 py-3 rounded-lg flex items-center justify-between&quot;&gt;
+  &lt;span&gt;Get 20% off your next purchase!&lt;/span&gt;
+  &lt;a href=&quot;#&quot; class=&quot;underline&quot;&gt;Shop Now&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Notification Banner -->
+        <section id="banner-notification" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Notification Banner</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">System alert or update.</p>
+              </div>
+              <button id="copy-banner-notification-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="banner-notification-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="banner-notification-html">HTML</button>
+            </nav>
+          </div>
+          <div id="banner-notification-preview" class="tab-content">
+            <div class="bg-blue-500 text-white px-4 py-3 rounded-lg">
+              <p>Your profile has been updated successfully.</p>
+            </div>
+          </div>
+          <div id="banner-notification-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;background-blue-500 text-white px-4 py-3 rounded-lg&quot;&gt;
+  &lt;p&gt;Your profile has been updated successfully.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Cookie Banner -->
+        <section id="banner-cookie" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Cookie Banner</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Privacy consent notice.</p>
+              </div>
+              <button id="copy-banner-cookie-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="banner-cookie-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="banner-cookie-html">HTML</button>
+            </nav>
+          </div>
+          <div id="banner-cookie-preview" class="tab-content">
+            <div class="bg-neutral-800 text-white px-4 py-3 rounded-lg flex items-center justify-between">
+              <span>This site uses cookies to improve your experience.</span>
+              <button class="bg-primary-500 hover:bg-primary-600 text-white px-3 py-1 rounded">Accept</button>
+            </div>
+          </div>
+          <div id="banner-cookie-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;background-neutral-800 text-white px-4 py-3 rounded-lg flex items-center justify-between&quot;&gt;
+  &lt;span&gt;This site uses cookies to improve your experience.&lt;/span&gt;
+  &lt;button class=&quot;bg-primary-500 hover:bg-primary-600 text-white px-3 py-1 rounded&quot;&gt;Accept&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('banner');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-banner-announcement-btn', content: 'banner-announcement-html' },
+          { id: 'copy-banner-promotional-btn', content: 'banner-promotional-html' },
+          { id: 'copy-banner-notification-btn', content: 'banner-notification-html' },
+          { id: 'copy-banner-cookie-btn', content: 'banner-cookie-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>

--- a/src/blocks/feedback-status/error/index.html
+++ b/src/blocks/feedback-status/error/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Error Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <a href="/src/blocks/feedback-status/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Feedback &amp; Status</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Error</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Error Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Error pages and messages for handling problems and guiding users.
+          </p>
+        </div>
+
+        <!-- Section: 404 Error Page -->
+        <section id="error-404" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">404 Error Page</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Simple not found message.</p>
+              </div>
+              <button id="copy-error-404-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="error-404-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="error-404-html">HTML</button>
+            </nav>
+          </div>
+          <div id="error-404-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 text-center space-y-4">
+              <h1 class="text-6xl font-bold text-primary-500">404</h1>
+              <p class="text-neutral-600 dark:text-neutral-400">Page not found</p>
+              <a href="/" class="inline-block bg-primary-500 hover:bg-primary-600 text-white px-6 py-3 rounded-lg">Go Home</a>
+            </div>
+          </div>
+          <div id="error-404-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;text-center space-y-4&quot;&gt;
+  &lt;h1 class=&quot;text-6xl font-bold text-primary-500&quot;&gt;404&lt;/h1&gt;
+  &lt;p class=&quot;text-neutral-600 dark:text-neutral-400&quot;&gt;Page not found&lt;/p&gt;
+  &lt;a href=&quot;/&quot; class=&quot;inline-block bg-primary-500 hover:bg-primary-600 text-white px-6 py-3 rounded-lg&quot;&gt;Go Home&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Error Message -->
+        <section id="error-message" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Error Message</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Inline alert style error.</p>
+              </div>
+              <button id="copy-error-message-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="error-message-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="error-message-html">HTML</button>
+            </nav>
+          </div>
+          <div id="error-message-preview" class="tab-content">
+            <div class="bg-red-100 border border-red-300 text-red-700 p-4 rounded-lg">
+              <p><strong>Error:</strong> Something went wrong.</p>
+            </div>
+          </div>
+          <div id="error-message-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;bg-red-100 border border-red-300 text-red-700 p-4 rounded-lg&quot;&gt;
+  &lt;p&gt;&lt;strong&gt;Error:&lt;/strong&gt; Something went wrong.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Maintenance Page -->
+        <section id="maintenance" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Maintenance Page</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Under maintenance notice.</p>
+              </div>
+              <button id="copy-maintenance-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="maintenance-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="maintenance-html">HTML</button>
+            </nav>
+          </div>
+          <div id="maintenance-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 text-center space-y-4">
+              <h1 class="text-4xl font-semibold text-primary-500">We'll be back soon!</h1>
+              <p class="text-neutral-600 dark:text-neutral-400">Our site is currently undergoing maintenance.</p>
+            </div>
+          </div>
+          <div id="maintenance-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;text-center space-y-4&quot;&gt;
+  &lt;h1 class=&quot;text-4xl font-semibold text-primary-500&quot;&gt;We'll be back soon!&lt;/h1&gt;
+  &lt;p class=&quot;text-neutral-600 dark:text-neutral-400&quot;&gt;Our site is currently undergoing maintenance.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Error Recovery -->
+        <section id="error-recovery" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Error Recovery</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Help and next steps.</p>
+              </div>
+              <button id="copy-error-recovery-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="error-recovery-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="error-recovery-html">HTML</button>
+            </nav>
+          </div>
+          <div id="error-recovery-preview" class="tab-content">
+            <div class="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-8 text-center space-y-4">
+              <h1 class="text-4xl font-semibold text-primary-500">Oops!</h1>
+              <p class="text-neutral-600 dark:text-neutral-400">Something went wrong. Please try again or contact support.</p>
+              <a href="/" class="inline-block bg-primary-500 hover:bg-primary-600 text-white px-6 py-3 rounded-lg">Retry</a>
+            </div>
+          </div>
+          <div id="error-recovery-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;text-center space-y-4&quot;&gt;
+  &lt;h1 class=&quot;text-4xl font-semibold text-primary-500&quot;&gt;Oops!&lt;/h1&gt;
+  &lt;p class=&quot;text-neutral-600 dark:text-neutral-400&quot;&gt;Something went wrong. Please try again or contact support.&lt;/p&gt;
+  &lt;a href=&quot;/&quot; class=&quot;inline-block bg-primary-500 hover:bg-primary-600 text-white px-6 py-3 rounded-lg&quot;&gt;Retry&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('error');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-error-404-btn', content: 'error-404-html' },
+          { id: 'copy-error-message-btn', content: 'error-message-html' },
+          { id: 'copy-maintenance-btn', content: 'maintenance-html' },
+          { id: 'copy-error-recovery-btn', content: 'error-recovery-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>

--- a/src/blocks/feedback-status/loading/index.html
+++ b/src/blocks/feedback-status/loading/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loading Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <a href="/src/blocks/feedback-status/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Feedback &amp; Status</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Loading</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Loading Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Loading indicators and skeleton screens for application states.
+          </p>
+        </div>
+
+        <!-- Section: Page Loading -->
+        <section id="page-loading" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Page Loading</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Fullscreen spinner overlay.</p>
+              </div>
+              <button id="copy-page-loading-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="page-loading-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="page-loading-html">HTML</button>
+            </nav>
+          </div>
+          <div id="page-loading-preview" class="tab-content">
+            <div class="flex items-center justify-center h-64">
+              <svg class="animate-spin h-10 w-10 text-primary-500" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4"></circle>
+                <path class="opacity-75" d="M4 12a8 8 0 018-8v8H4z" stroke-width="4"></path>
+              </svg>
+            </div>
+          </div>
+          <div id="page-loading-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;flex items-center justify-center h-64&quot;&gt;
+  &lt;svg class=&quot;animate-spin h-10 w-10 text-primary-500&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;none&quot; stroke=&quot;currentColor&quot;&gt;
+    &lt;circle class=&quot;opacity-25&quot; cx=&quot;12&quot; cy=&quot;12&quot; r=&quot;10&quot; stroke-width=&quot;4&quot;&gt;&lt;/circle&gt;
+    &lt;path class=&quot;opacity-75&quot; d=&quot;M4 12a8 8 0 018-8v8H4z&quot; stroke-width=&quot;4&quot;&gt;&lt;/path&gt;
+  &lt;/svg&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Content Loading -->
+        <section id="content-loading" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Content Loading</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Spinner within a section.</p>
+              </div>
+              <button id="copy-content-loading-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="content-loading-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="content-loading-html">HTML</button>
+            </nav>
+          </div>
+          <div id="content-loading-preview" class="tab-content">
+            <div class="h-32 flex items-center justify-center">
+              <svg class="animate-spin h-8 w-8 text-primary-500" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4"></circle>
+                <path class="opacity-75" d="M4 12a8 8 0 018-8v8H4z" stroke-width="4"></path>
+              </svg>
+            </div>
+          </div>
+          <div id="content-loading-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;h-32 flex items-center justify-center&quot;&gt;
+  &lt;svg class=&quot;animate-spin h-8 w-8 text-primary-500&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;none&quot; stroke=&quot;currentColor&quot;&gt;
+    &lt;circle class=&quot;opacity-25&quot; cx=&quot;12&quot; cy=&quot;12&quot; r=&quot;10&quot; stroke-width=&quot;4&quot;&gt;&lt;/circle&gt;
+    &lt;path class=&quot;opacity-75&quot; d=&quot;M4 12a8 8 0 018-8v8H4z&quot; stroke-width=&quot;4&quot;&gt;&lt;/path&gt;
+  &lt;/svg&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Progress Indicator -->
+        <section id="progress-indicator" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Progress Indicator</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Simple progress bar.</p>
+              </div>
+              <button id="copy-progress-indicator-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="progress-indicator-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="progress-indicator-html">HTML</button>
+            </nav>
+          </div>
+          <div id="progress-indicator-preview" class="tab-content">
+            <div class="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2">
+              <div class="bg-primary-500 h-2 rounded-full" style="width:50%"></div>
+            </div>
+          </div>
+          <div id="progress-indicator-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2&quot;&gt;
+  &lt;div class=&quot;bg-primary-500 h-2 rounded-full&quot; style=&quot;width:50%&quot;&gt;&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Skeleton Loading -->
+        <section id="skeleton-loading" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Skeleton Loading</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Placeholder content.</p>
+              </div>
+              <button id="copy-skeleton-loading-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="skeleton-loading-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="skeleton-loading-html">HTML</button>
+            </nav>
+          </div>
+          <div id="skeleton-loading-preview" class="tab-content">
+            <div class="animate-pulse space-y-2">
+              <div class="h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-3/4"></div>
+              <div class="h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-full"></div>
+              <div class="h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-5/6"></div>
+            </div>
+          </div>
+          <div id="skeleton-loading-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;animate-pulse space-y-2&quot;&gt;
+  &lt;div class=&quot;h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-3/4&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-full&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;h-4 bg-neutral-300 dark:bg-neutral-700 rounded w-5/6&quot;&gt;&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('loading');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-page-loading-btn', content: 'page-loading-html' },
+          { id: 'copy-content-loading-btn', content: 'content-loading-html' },
+          { id: 'copy-progress-indicator-btn', content: 'progress-indicator-html' },
+          { id: 'copy-skeleton-loading-btn', content: 'skeleton-loading-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>

--- a/src/blocks/feedback-status/modal/index.html
+++ b/src/blocks/feedback-status/modal/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal Block - UI11 Design System</title>
+  <link href="/src/style.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+</head>
+<body class="min-h-screen bg-white dark:bg-neutral-950">
+  <div class="flex min-h-screen">
+    <div id="sidebar-container"></div>
+    <div class="flex-1 flex flex-col ml-64 mt-16">
+      <div id="header-container"></div>
+      <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 overflow-hidden">
+        <nav class="flex mb-8" aria-label="Breadcrumb">
+          <ol class="flex items-center space-x-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <li><a href="/src/blocks/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Blocks</a></li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <a href="/src/blocks/feedback-status/" class="hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors duration-normal">Feedback &amp; Status</a>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-4 h-4 mx-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              <span class="text-neutral-900 dark:text-neutral-100 font-medium">Modal</span>
+            </li>
+          </ol>
+        </nav>
+        <div class="mb-12">
+          <h1 class="text-4xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">Modal Block</h1>
+          <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl leading-relaxed">
+            Dialog windows for confirmations, content, and more.
+          </p>
+        </div>
+
+        <!-- Section: Confirmation Modal -->
+        <section id="modal-confirmation" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Confirmation Modal</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Ask before performing an action.</p>
+              </div>
+              <button id="copy-modal-confirmation-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="modal-confirmation-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="modal-confirmation-html">HTML</button>
+            </nav>
+          </div>
+          <div id="modal-confirmation-preview" class="tab-content">
+            <div class="relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80 mx-auto">
+              <p class="mb-4 text-neutral-700 dark:text-neutral-300">Are you sure you want to continue?</p>
+              <div class="flex justify-end gap-2">
+                <button class="px-4 py-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">Cancel</button>
+                <button class="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg">Confirm</button>
+              </div>
+            </div>
+          </div>
+          <div id="modal-confirmation-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80&quot;&gt;
+  &lt;p class=&quot;mb-4 text-neutral-700 dark:text-neutral-300&quot;&gt;Are you sure you want to continue?&lt;/p&gt;
+  &lt;div class=&quot;flex justify-end gap-2&quot;&gt;
+    &lt;button class=&quot;px-4 py-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg&quot;&gt;Cancel&lt;/button&gt;
+    &lt;button class=&quot;px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg&quot;&gt;Confirm&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Content Modal -->
+        <section id="modal-content" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Content Modal</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Display information in a dialog.</p>
+              </div>
+              <button id="copy-modal-content-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="modal-content-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="modal-content-html">HTML</button>
+            </nav>
+          </div>
+          <div id="modal-content-preview" class="tab-content">
+            <div class="relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80 mx-auto">
+              <h3 class="text-lg font-semibold mb-2 text-neutral-900 dark:text-neutral-100">Modal Title</h3>
+              <p class="text-neutral-700 dark:text-neutral-300">This modal contains informational content for the user.</p>
+            </div>
+          </div>
+          <div id="modal-content-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80&quot;&gt;
+  &lt;h3 class=&quot;text-lg font-semibold mb-2 text-neutral-900 dark:text-neutral-100&quot;&gt;Modal Title&lt;/h3&gt;
+  &lt;p class=&quot;text-neutral-700 dark:text-neutral-300&quot;&gt;This modal contains informational content for the user.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Form Modal -->
+        <section id="modal-form" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Form Modal</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Collect information in a dialog.</p>
+              </div>
+              <button id="copy-modal-form-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="modal-form-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="modal-form-html">HTML</button>
+            </nav>
+          </div>
+          <div id="modal-form-preview" class="tab-content">
+            <div class="relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80 mx-auto space-y-4">
+              <input type="text" placeholder="Name" class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100" />
+              <div class="flex justify-end gap-2">
+                <button class="px-4 py-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg">Cancel</button>
+                <button class="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg">Submit</button>
+              </div>
+            </div>
+          </div>
+          <div id="modal-form-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;relative p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-lg w-80 space-y-4&quot;&gt;
+  &lt;input type=&quot;text&quot; placeholder=&quot;Name&quot; class=&quot;w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100&quot; /&gt;
+  &lt;div class=&quot;flex justify-end gap-2&quot;&gt;
+    &lt;button class=&quot;px-4 py-2 bg-neutral-100 dark:bg-neutral-700 rounded-lg&quot;&gt;Cancel&lt;/button&gt;
+    &lt;button class=&quot;px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg&quot;&gt;Submit&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section: Image Modal -->
+        <section id="modal-image" class="mb-16">
+          <div class="mb-8">
+            <div class="flex items-center justify-between mb-6">
+              <div>
+                <h2 class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-2">Image Modal</h2>
+                <p class="text-neutral-600 dark:text-neutral-400">Lightbox style image preview.</p>
+              </div>
+              <button id="copy-modal-image-btn" class="flex items-center gap-2 px-4 py-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg text-sm font-medium transition-colors duration-normal">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                Copy
+              </button>
+            </div>
+            <nav class="inline-flex bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1 mb-6">
+              <button class="tab-button active px-4 py-2 rounded-md bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 font-medium text-sm shadow-sm transition-all duration-normal" data-tab="modal-image-preview">Preview</button>
+              <button class="tab-button px-4 py-2 rounded-md text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium text-sm transition-all duration-normal" data-tab="modal-image-html">HTML</button>
+            </nav>
+          </div>
+          <div id="modal-image-preview" class="tab-content">
+            <div class="relative p-0 bg-transparent rounded-lg shadow-lg w-80 mx-auto">
+              <img src="https://via.placeholder.com/320x180" alt="Preview" class="rounded-lg" />
+            </div>
+          </div>
+          <div id="modal-image-html" class="tab-content hidden w-[768px]">
+            <div class="bg-neutral-900 dark:bg-neutral-950 rounded-lg overflow-hidden">
+              <pre class="p-6 text-sm overflow-x-auto"><code class="language-html whitespace-pre break-words">&lt;div class=&quot;relative p-0 bg-transparent rounded-lg shadow-lg w-80&quot;&gt;
+  &lt;img src=&quot;https://via.placeholder.com/320x180&quot; alt=&quot;Preview&quot; class=&quot;rounded-lg&quot; /&gt;
+&lt;/div&gt;</code></pre>
+            </div>
+          </div>
+        </section>
+      </main>
+      <div id="footer-container"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { generateHeader, generateSidebar, generateFooter, initializeSharedComponents } from '/src/shared/components.js';
+    import { themeManager } from '/src/shared/theme.js';
+    import { toast } from '/src/shared/toast.js';
+
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('header-container').innerHTML = generateHeader('blocks');
+      document.getElementById('sidebar-container').innerHTML = generateSidebar('modal');
+      document.getElementById('footer-container').innerHTML = generateFooter();
+
+      initializeSharedComponents();
+      themeManager.initializeToggleButtons();
+
+      function initTabs() {
+        const tabButtons = document.querySelectorAll('.tab-button');
+        tabButtons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            const target = btn.getAttribute('data-tab');
+            const section = btn.closest('section');
+            section.querySelectorAll('.tab-button').forEach(b => {
+              b.classList.remove('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+              b.classList.add('text-neutral-600', 'dark:text-neutral-400');
+            });
+            btn.classList.add('active', 'bg-white', 'dark:bg-neutral-700', 'text-neutral-900', 'dark:text-neutral-100', 'shadow-sm');
+            btn.classList.remove('text-neutral-600', 'dark:text-neutral-400');
+            section.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
+            const content = section.querySelector(`#${target}`);
+            if (content) content.classList.remove('hidden');
+          });
+        });
+      }
+
+      function initCopyButtons() {
+        const buttons = [
+          { id: 'copy-modal-confirmation-btn', content: 'modal-confirmation-html' },
+          { id: 'copy-modal-content-btn', content: 'modal-content-html' },
+          { id: 'copy-modal-form-btn', content: 'modal-form-html' },
+          { id: 'copy-modal-image-btn', content: 'modal-image-html' }
+        ];
+        buttons.forEach(({ id, content }) => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.addEventListener('click', () => {
+              const code = document.querySelector(`#${content} code`).textContent;
+              navigator.clipboard.writeText(code).then(() => {
+                toast.show('Code copied to clipboard!', 'success');
+              });
+            });
+          }
+        });
+      }
+
+      initTabs();
+      initCopyButtons();
+    });
+  </script>
+</body>
+</html>

--- a/tasks.md
+++ b/tasks.md
@@ -1006,11 +1006,11 @@ Before marking any item "done":
  - ⬜ **Timeline Block**: 4 variations (pending)
  - ⬜ **Stats Block**: 4 variations (pending)
 
-**Feedback & Status Category (0/4 complete)** ⬜ 0%:
-- ⬜ **Error Block**: 4 variations (pending)
-- ⬜ **Loading Block**: 4 variations (pending)
-- ⬜ **Modal Block**: 4 variations (pending)
-- ⬜ **Banner Block**: 4 variations (pending)
+**Feedback & Status Category (4/4 complete)** ✅ 100%:
+ - ✅ **Error Block**: 4 variations ✅ **COMPLETED**
+ - ✅ **Loading Block**: 4 variations ✅ **COMPLETED**
+ - ✅ **Modal Block**: 4 variations ✅ **COMPLETED**
+ - ✅ **Banner Block**: 4 variations ✅ **COMPLETED**
 
 **Specialized Category (0/4 complete)** ⬜ 0%:
 - ⬜ **Login Block**: 4 variations (pending)
@@ -1018,4 +1018,4 @@ Before marking any item "done":
 - ⬜ **Table Block**: 4 variations (pending)
 - ⬜ **Tabs Block**: 4 variations (pending)
 
-**Overall Blocks Progress**: 8/35 elements completed (23%), 54/147 variations completed (37%)
+**Overall Blocks Progress**: 12/35 elements completed (34%), 70/147 variations completed (48%)


### PR DESCRIPTION
## Summary
- add Error, Loading, Modal and Banner block pages with code/preview tabs
- update task list for Feedback & Status category

## Testing
- `npm run tw:build` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842345e0ce8833396011f572ea68e8b